### PR TITLE
Set minute to 0 in hour cron

### DIFF
--- a/cron/index.js
+++ b/cron/index.js
@@ -14,9 +14,9 @@ function intervalAsCron( interval, period ) {
 	if ( period === 'minute' ) {
 		return `*/${ Math.min( interval, 59 ) } * * * *`;
 	} else if ( period === 'hour' ) {
-		return `* */${ Math.min( interval, 23 ) } * * *`;
+		return `0 */${ Math.min( interval, 23 ) } * * *`;
 	} else if ( period === 'day' ) {
-		return `* * */${ interval } * *`;
+		return `0 0 */${ interval } * *`;
 	}
 }
 


### PR DESCRIPTION
Setting an hourly schedule would leave `*` as the minute value, meaning that it fired every minute. Set it to 0 so it fires on the hour